### PR TITLE
Updated upstream and ignored unwanted compilations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.db
 *.db-wal
 *.lock
+rust/target/
+rust/ejdb-sys/target/

--- a/rust/ejdb-sys/build.rs
+++ b/rust/ejdb-sys/build.rs
@@ -13,8 +13,9 @@ fn main() {
     let dst = Config::new("ejdb-upstream")
         .cflag("-w")
         .profile("Debug")
-        .define("BUILD_SAMPLES", "OFF")
+        .define("BUILD_EXAMPLES", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF")
+        .define("ENABLE_HTTP", "OFF")
         .build();
 
     Command::new("make").status().expect("failed to make!");


### PR DESCRIPTION
compilation for examples in EJDB2 can be configured using `BUILD_EXAMPLES` instead of `BUILD_SAMPLES`.
https://github.com/Softmotions/ejdb/blob/ecae9c8db6b009b0757aee1e593d7fa064c2bc5b/CMakeLists.txt#L39

Since this is a library and we do not want to compile the HTTP and STANDALONE server.
https://github.com/Softmotions/ejdb/blob/ecae9c8db6b009b0757aee1e593d7fa064c2bc5b/CMakeLists.txt#L36